### PR TITLE
 feat: 커스텀 스케줄 생성/수정/삭제 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### Codex CLI ###
 AGENTS.md
+AGENT_CONTEXT.md

--- a/src/main/java/grewmeet/schedulecommandservice/controller/ScheduleController.java
+++ b/src/main/java/grewmeet/schedulecommandservice/controller/ScheduleController.java
@@ -1,0 +1,36 @@
+package grewmeet.schedulecommandservice.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import grewmeet.schedulecommandservice.dto.CreateCustomScheduleRequest;
+import grewmeet.schedulecommandservice.dto.DeleteCustomScheduleRequest;
+import grewmeet.schedulecommandservice.dto.UpdateCustomScheduleRequest;
+
+@RestController
+@RequestMapping("/schedules")
+@Validated
+public class ScheduleController {
+
+    @PostMapping("/custom")
+    public ResponseEntity<Void> createCustomSchedule(@RequestBody CreateCustomScheduleRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PatchMapping("/custom")
+    public ResponseEntity<Void> updateCustomSchedule(@RequestBody UpdateCustomScheduleRequest request) {
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/custom")
+    public ResponseEntity<Void> deleteCustomSchedule(@RequestBody DeleteCustomScheduleRequest request) {
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/grewmeet/schedulecommandservice/controller/ScheduleController.java
+++ b/src/main/java/grewmeet/schedulecommandservice/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package grewmeet.schedulecommandservice.controller;
 
+import grewmeet.schedulecommandservice.dto.ScheduleResponse;
 import grewmeet.schedulecommandservice.service.ScheduleCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,22 +29,27 @@ public class ScheduleController {
     private final ScheduleCommandService scheduleCommandService;
 
     @PostMapping("/custom")
-    public ResponseEntity<Void> createCustomSchedule(@RequestHeader("X-Owner-Id") UUID ownerId,
-                                                     @RequestBody @Valid CreateCustomScheduleRequest request) {
-        scheduleCommandService.createCustom(ownerId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+    public ResponseEntity<ScheduleResponse> createCustomSchedule(
+            @RequestHeader("X-Owner-Id") UUID ownerId,
+            @RequestBody @Valid CreateCustomScheduleRequest request) {
+        ScheduleResponse created = scheduleCommandService.createCustomSchedule(ownerId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", "/schedules/custom/" + created.scheduleId())
+                .body(created);
     }
 
     @PatchMapping("/custom")
-    public ResponseEntity<Void> updateCustomSchedule(@RequestHeader("X-Owner-Id") UUID ownerId,
-                                                     @RequestBody @Valid UpdateCustomScheduleRequest request) {
+    public ResponseEntity<Void> updateCustomSchedule(
+            @RequestHeader("X-Owner-Id") UUID ownerId,
+            @RequestBody @Valid UpdateCustomScheduleRequest request) {
         scheduleCommandService.patchCustom(ownerId, request);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/custom")
-    public ResponseEntity<Void> deleteCustomSchedule(@RequestHeader("X-Owner-Id") UUID ownerId,
-                                                     @RequestBody @Valid DeleteCustomScheduleRequest request) {
+    public ResponseEntity<Void> deleteCustomSchedule(
+            @RequestHeader("X-Owner-Id") UUID ownerId,
+            @RequestBody @Valid DeleteCustomScheduleRequest request) {
         scheduleCommandService.deleteCustom(ownerId, request);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/grewmeet/schedulecommandservice/controller/ScheduleController.java
+++ b/src/main/java/grewmeet/schedulecommandservice/controller/ScheduleController.java
@@ -1,5 +1,7 @@
 package grewmeet.schedulecommandservice.controller;
 
+import grewmeet.schedulecommandservice.service.ScheduleCommandService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -7,30 +9,42 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import grewmeet.schedulecommandservice.dto.CreateCustomScheduleRequest;
 import grewmeet.schedulecommandservice.dto.DeleteCustomScheduleRequest;
 import grewmeet.schedulecommandservice.dto.UpdateCustomScheduleRequest;
+import jakarta.validation.Valid;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/schedules")
 @Validated
+@RequiredArgsConstructor
 public class ScheduleController {
 
+    private final ScheduleCommandService scheduleCommandService;
+
     @PostMapping("/custom")
-    public ResponseEntity<Void> createCustomSchedule(@RequestBody CreateCustomScheduleRequest request) {
+    public ResponseEntity<Void> createCustomSchedule(@RequestHeader("X-Owner-Id") UUID ownerId,
+                                                     @RequestBody @Valid CreateCustomScheduleRequest request) {
+        scheduleCommandService.createCustom(ownerId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/custom")
-    public ResponseEntity<Void> updateCustomSchedule(@RequestBody UpdateCustomScheduleRequest request) {
+    public ResponseEntity<Void> updateCustomSchedule(@RequestHeader("X-Owner-Id") UUID ownerId,
+                                                     @RequestBody @Valid UpdateCustomScheduleRequest request) {
+        scheduleCommandService.patchCustom(ownerId, request);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/custom")
-    public ResponseEntity<Void> deleteCustomSchedule(@RequestBody DeleteCustomScheduleRequest request) {
+    public ResponseEntity<Void> deleteCustomSchedule(@RequestHeader("X-Owner-Id") UUID ownerId,
+                                                     @RequestBody @Valid DeleteCustomScheduleRequest request) {
+        scheduleCommandService.deleteCustom(ownerId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/grewmeet/schedulecommandservice/domain/Schedule.java
+++ b/src/main/java/grewmeet/schedulecommandservice/domain/Schedule.java
@@ -1,5 +1,6 @@
 package grewmeet.schedulecommandservice.domain;
 
+import jakarta.persistence.Column;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,19 +25,21 @@ public class Schedule {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private UUID scheduleId;
 
     private UUID ownerId;
 
+    @Column(nullable = false)
     private String title;
 
     private String description;
 
+    @Column(nullable = false)
     private LocalDateTime startAt;
 
+    @Column(nullable = false)
     private LocalDateTime endAt;
-
-    private boolean allDay;
 
     @Enumerated(EnumType.STRING)
     private ScheduleSource source = ScheduleSource.CUSTOM;
@@ -65,5 +68,42 @@ public class Schedule {
                                         LocalDateTime startAt,
                                         LocalDateTime endAt) {
         return new Schedule(ownerId, scheduleId, title, description, startAt, endAt);
+    }
+
+    public void applyPatch(String title,
+                           String description,
+                           LocalDateTime startAt,
+                           LocalDateTime endAt) {
+        require(title,startAt,endAt);
+        this.title = title;
+        this.description = description;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    private void require(String title,
+                          LocalDateTime startAt,
+                          LocalDateTime endAt) {
+        requireStartBeforeEnd(startAt, endAt);
+        requireNonBlankTitle(title);
+        requireNonZeroDuration(startAt, endAt);
+    }
+
+    private void requireStartBeforeEnd(LocalDateTime startAt, LocalDateTime endAt) {
+        if(endAt.isBefore(startAt)) {
+            throw new IllegalArgumentException("End time must be before start time");
+        }
+    }
+
+    private void requireNonBlankTitle(String title) {
+        if(title == null || title.isBlank()) {
+            throw new IllegalArgumentException("Title cannot be blank");
+        }
+    }
+
+    private void requireNonZeroDuration(LocalDateTime startAt, LocalDateTime endAt) {
+        if(startAt.equals(endAt)) {
+            throw new IllegalArgumentException("End time must have gap to start time");
+        }
     }
 }

--- a/src/main/java/grewmeet/schedulecommandservice/domain/Schedule.java
+++ b/src/main/java/grewmeet/schedulecommandservice/domain/Schedule.java
@@ -1,0 +1,68 @@
+package grewmeet.schedulecommandservice.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private UUID scheduleId;
+
+    private UUID ownerId;
+
+    private String title;
+
+    private String description;
+
+    private LocalDateTime startAt;
+
+    private LocalDateTime endAt;
+
+    private String location;
+
+    private boolean allDay;
+
+    @Enumerated(EnumType.STRING)
+    private ScheduleSource source = ScheduleSource.CUSTOM;
+
+    @Version
+    private Long version;
+
+    public Schedule(UUID ownerId,
+                    UUID scheduleId,
+                    String title,
+                    String description,
+                    LocalDateTime startAt,
+                    LocalDateTime endAt,
+                    String location,
+                    boolean allDay,
+                    ScheduleSource source) {
+        this.ownerId = ownerId;
+        this.scheduleId = scheduleId;
+        this.title = title;
+        this.description = description;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.location = location;
+        this.allDay = allDay;
+        this.source = source == null ? ScheduleSource.CUSTOM : source;
+    }
+}

--- a/src/main/java/grewmeet/schedulecommandservice/domain/Schedule.java
+++ b/src/main/java/grewmeet/schedulecommandservice/domain/Schedule.java
@@ -36,8 +36,6 @@ public class Schedule {
 
     private LocalDateTime endAt;
 
-    private String location;
-
     private boolean allDay;
 
     @Enumerated(EnumType.STRING)
@@ -46,23 +44,26 @@ public class Schedule {
     @Version
     private Long version;
 
-    public Schedule(UUID ownerId,
-                    UUID scheduleId,
-                    String title,
-                    String description,
-                    LocalDateTime startAt,
-                    LocalDateTime endAt,
-                    String location,
-                    boolean allDay,
-                    ScheduleSource source) {
+    private Schedule(UUID ownerId,
+                     UUID scheduleId,
+                     String title,
+                     String description,
+                     LocalDateTime startAt,
+                     LocalDateTime endAt) {
         this.ownerId = ownerId;
         this.scheduleId = scheduleId;
         this.title = title;
         this.description = description;
         this.startAt = startAt;
         this.endAt = endAt;
-        this.location = location;
-        this.allDay = allDay;
-        this.source = source == null ? ScheduleSource.CUSTOM : source;
+    }
+
+    public static Schedule createCustom(UUID ownerId,
+                                        UUID scheduleId,
+                                        String title,
+                                        String description,
+                                        LocalDateTime startAt,
+                                        LocalDateTime endAt) {
+        return new Schedule(ownerId, scheduleId, title, description, startAt, endAt);
     }
 }

--- a/src/main/java/grewmeet/schedulecommandservice/domain/ScheduleSource.java
+++ b/src/main/java/grewmeet/schedulecommandservice/domain/ScheduleSource.java
@@ -1,0 +1,8 @@
+package grewmeet.schedulecommandservice.domain;
+
+public enum ScheduleSource {
+    CUSTOM,
+    DATING,
+    STUDY
+}
+

--- a/src/main/java/grewmeet/schedulecommandservice/dto/CreateCustomScheduleRequest.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/CreateCustomScheduleRequest.java
@@ -9,7 +9,5 @@ public record CreateCustomScheduleRequest(
         @NotBlank String title,
         String description,
         @NotNull LocalDateTime startAt,
-        @NotNull LocalDateTime endAt,
-        String location,
-        boolean allDay
+        @NotNull LocalDateTime endAt
 ) {}

--- a/src/main/java/grewmeet/schedulecommandservice/dto/CreateCustomScheduleRequest.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/CreateCustomScheduleRequest.java
@@ -1,0 +1,15 @@
+package grewmeet.schedulecommandservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record CreateCustomScheduleRequest(
+        @NotBlank String title,
+        String description,
+        @NotNull LocalDateTime startAt,
+        @NotNull LocalDateTime endAt,
+        String location,
+        boolean allDay
+) {}

--- a/src/main/java/grewmeet/schedulecommandservice/dto/DeleteCustomScheduleRequest.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/DeleteCustomScheduleRequest.java
@@ -1,0 +1,8 @@
+package grewmeet.schedulecommandservice.dto;
+
+import java.util.UUID;
+
+public record DeleteCustomScheduleRequest(
+        UUID scheduleId
+) {}
+

--- a/src/main/java/grewmeet/schedulecommandservice/dto/DeleteCustomScheduleRequest.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/DeleteCustomScheduleRequest.java
@@ -1,8 +1,8 @@
 package grewmeet.schedulecommandservice.dto;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record DeleteCustomScheduleRequest(
-        UUID scheduleId
+        @NotNull UUID scheduleId
 ) {}
-

--- a/src/main/java/grewmeet/schedulecommandservice/dto/ScheduleResponse.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/ScheduleResponse.java
@@ -13,11 +13,7 @@ public record ScheduleResponse(
         String title,
         String description,
         LocalDateTime startAt,
-        LocalDateTime endAt,
-        String location,
-        boolean allDay,
-        ScheduleSource source,
-        Long version
+        LocalDateTime endAt
 ) {
     public static ScheduleResponse from(Schedule s) {
         return new ScheduleResponse(
@@ -27,11 +23,7 @@ public record ScheduleResponse(
                 s.getTitle(),
                 s.getDescription(),
                 s.getStartAt(),
-                s.getEndAt(),
-                s.getLocation(),
-                s.isAllDay(),
-                s.getSource(),
-                s.getVersion()
+                s.getEndAt()
         );
     }
 }

--- a/src/main/java/grewmeet/schedulecommandservice/dto/ScheduleResponse.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/ScheduleResponse.java
@@ -1,0 +1,37 @@
+package grewmeet.schedulecommandservice.dto;
+
+import grewmeet.schedulecommandservice.domain.Schedule;
+import grewmeet.schedulecommandservice.domain.ScheduleSource;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ScheduleResponse(
+        Long id,
+        UUID scheduleId,
+        UUID ownerId,
+        String title,
+        String description,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        String location,
+        boolean allDay,
+        ScheduleSource source,
+        Long version
+) {
+    public static ScheduleResponse from(Schedule s) {
+        return new ScheduleResponse(
+                s.getId(),
+                s.getScheduleId(),
+                s.getOwnerId(),
+                s.getTitle(),
+                s.getDescription(),
+                s.getStartAt(),
+                s.getEndAt(),
+                s.getLocation(),
+                s.isAllDay(),
+                s.getSource(),
+                s.getVersion()
+        );
+    }
+}

--- a/src/main/java/grewmeet/schedulecommandservice/dto/UpdateCustomScheduleRequest.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/UpdateCustomScheduleRequest.java
@@ -9,7 +9,5 @@ public record UpdateCustomScheduleRequest(
         String title,
         String description,
         LocalDateTime startAt,
-        LocalDateTime endAt,
-        String location,
-        Boolean allDay
+        LocalDateTime endAt
 ) {}

--- a/src/main/java/grewmeet/schedulecommandservice/dto/UpdateCustomScheduleRequest.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/UpdateCustomScheduleRequest.java
@@ -1,0 +1,14 @@
+package grewmeet.schedulecommandservice.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdateCustomScheduleRequest(
+        UUID scheduleId,
+        String title,
+        String description,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        String location,
+        Boolean allDay
+) {}

--- a/src/main/java/grewmeet/schedulecommandservice/dto/UpdateCustomScheduleRequest.java
+++ b/src/main/java/grewmeet/schedulecommandservice/dto/UpdateCustomScheduleRequest.java
@@ -1,10 +1,11 @@
 package grewmeet.schedulecommandservice.dto;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record UpdateCustomScheduleRequest(
-        UUID scheduleId,
+        @NotNull UUID scheduleId,
         String title,
         String description,
         LocalDateTime startAt,

--- a/src/main/java/grewmeet/schedulecommandservice/repository/ScheduleRepository.java
+++ b/src/main/java/grewmeet/schedulecommandservice/repository/ScheduleRepository.java
@@ -2,7 +2,9 @@ package grewmeet.schedulecommandservice.repository;
 
 import grewmeet.schedulecommandservice.domain.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    Optional<Schedule> findByScheduleIdAndOwnerId(UUID scheduleId, UUID ownerId);
 }
-

--- a/src/main/java/grewmeet/schedulecommandservice/repository/ScheduleRepository.java
+++ b/src/main/java/grewmeet/schedulecommandservice/repository/ScheduleRepository.java
@@ -1,0 +1,8 @@
+package grewmeet.schedulecommandservice.repository;
+
+import grewmeet.schedulecommandservice.domain.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}
+

--- a/src/main/java/grewmeet/schedulecommandservice/repository/ScheduleRepository.java
+++ b/src/main/java/grewmeet/schedulecommandservice/repository/ScheduleRepository.java
@@ -6,5 +6,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    Optional<Schedule> findByUuid(UUID uuid);
     Optional<Schedule> findByScheduleIdAndOwnerId(UUID scheduleId, UUID ownerId);
 }

--- a/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandService.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandService.java
@@ -10,8 +10,7 @@ import java.util.UUID;
 public interface ScheduleCommandService {
     ScheduleResponse createCustomSchedule(UUID ownerId, CreateCustomScheduleRequest request);
 
-    ScheduleResponse patchCustom(UUID ownerId, UpdateCustomScheduleRequest request);
+    void patchCustom(UUID ownerId, UpdateCustomScheduleRequest request);
 
     void deleteCustom(UUID ownerId, DeleteCustomScheduleRequest request);
 }
-

--- a/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandService.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandService.java
@@ -8,7 +8,7 @@ import grewmeet.schedulecommandservice.dto.UpdateCustomScheduleRequest;
 import java.util.UUID;
 
 public interface ScheduleCommandService {
-    ScheduleResponse createCustom(UUID ownerId, CreateCustomScheduleRequest request);
+    ScheduleResponse createCustomSchedule(UUID ownerId, CreateCustomScheduleRequest request);
 
     ScheduleResponse patchCustom(UUID ownerId, UpdateCustomScheduleRequest request);
 

--- a/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandService.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandService.java
@@ -1,0 +1,17 @@
+package grewmeet.schedulecommandservice.service;
+
+import grewmeet.schedulecommandservice.dto.CreateCustomScheduleRequest;
+import grewmeet.schedulecommandservice.dto.DeleteCustomScheduleRequest;
+import grewmeet.schedulecommandservice.dto.ScheduleResponse;
+import grewmeet.schedulecommandservice.dto.UpdateCustomScheduleRequest;
+
+import java.util.UUID;
+
+public interface ScheduleCommandService {
+    ScheduleResponse createCustom(UUID ownerId, CreateCustomScheduleRequest request);
+
+    ScheduleResponse patchCustom(UUID ownerId, UpdateCustomScheduleRequest request);
+
+    void deleteCustom(UUID ownerId, DeleteCustomScheduleRequest request);
+}
+

--- a/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package grewmeet.schedulecommandservice.service;
 
+import grewmeet.schedulecommandservice.domain.Schedule;
 import grewmeet.schedulecommandservice.dto.CreateCustomScheduleRequest;
 import grewmeet.schedulecommandservice.dto.DeleteCustomScheduleRequest;
 import grewmeet.schedulecommandservice.dto.ScheduleResponse;
@@ -17,8 +18,16 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
     private final ScheduleRepository scheduleRepository;
 
     @Override
-    public ScheduleResponse createCustom(UUID ownerId, CreateCustomScheduleRequest request) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    public ScheduleResponse createCustomSchedule(UUID ownerId, CreateCustomScheduleRequest request) {
+        UUID scheduleId = UUID.randomUUID();
+        Schedule schedule = Schedule.createCustom(
+                ownerId,
+                scheduleId,
+                request.title(),
+                request.description(),
+                request.startAt(),
+                request.endAt());
+        return ScheduleResponse.from(scheduleRepository.save(schedule));
     }
 
     @Override

--- a/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
@@ -1,0 +1,34 @@
+package grewmeet.schedulecommandservice.service;
+
+import grewmeet.schedulecommandservice.dto.CreateCustomScheduleRequest;
+import grewmeet.schedulecommandservice.dto.DeleteCustomScheduleRequest;
+import grewmeet.schedulecommandservice.dto.ScheduleResponse;
+import grewmeet.schedulecommandservice.dto.UpdateCustomScheduleRequest;
+import grewmeet.schedulecommandservice.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleCommandServiceImpl implements ScheduleCommandService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    @Override
+    public ScheduleResponse createCustom(UUID ownerId, CreateCustomScheduleRequest request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ScheduleResponse patchCustom(UUID ownerId, UpdateCustomScheduleRequest request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void deleteCustom(UUID ownerId, DeleteCustomScheduleRequest request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}
+

--- a/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
@@ -45,6 +45,10 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
 
     @Override
     public void deleteCustom(UUID ownerId, DeleteCustomScheduleRequest request) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        Schedule schedule = scheduleRepository
+                .findByScheduleIdAndOwnerId(request.scheduleId(), ownerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        scheduleRepository.delete(schedule);
     }
 }

--- a/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/ScheduleCommandServiceImpl.java
@@ -7,8 +7,11 @@ import grewmeet.schedulecommandservice.dto.ScheduleResponse;
 import grewmeet.schedulecommandservice.dto.UpdateCustomScheduleRequest;
 import grewmeet.schedulecommandservice.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -31,8 +34,13 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
     }
 
     @Override
-    public ScheduleResponse patchCustom(UUID ownerId, UpdateCustomScheduleRequest request) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    public void patchCustom(UUID ownerId, UpdateCustomScheduleRequest request) {
+        Schedule schedule = scheduleRepository
+                .findByScheduleIdAndOwnerId(request.scheduleId(), ownerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        schedule.applyPatch(request.title(), request.description(), request.startAt(), request.endAt());
+        scheduleRepository.save(schedule);
     }
 
     @Override
@@ -40,4 +48,3 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }
-


### PR DESCRIPTION
 ## Summary
 - 커스텀 스케줄 생성, 수정(PATCH), 삭제 기능 추가
 - 시간/제목 검증을 도메인(Schedule)에서 수행하도록 일원화
 
## Schedule Command Service — TODO
 - [x] 커스텀 스케쥴 기능 구현
    - [x] 커스텀 스케줄 생성 서비스 구현
    - [x] 커스텀 스케줄 수정(PATCH) 서비스 구현
    - [x] 커스텀 스케줄 삭제 서비스 구현
- [ ] Kafka EventHandler(Publisher) 구현 (Command to Query)
- [ ] Kafka EventHandler(Subscriber) 구현 (from Dating domani, Study Domain)
- [ ] DTO 입력 제약(길이/형식 등) 정교화
- [ ] 운영 프로필(MySQL) DDL 검증 및 마이그레이션(Flyway/Liquibase) 준비