### PR TITLE
feat: 커스텀 스케줄 이벤트 퍼블리셔 추가 및 서비스 연동

### DIFF
--- a/event/schema/README.md
+++ b/event/schema/README.md
@@ -1,0 +1,64 @@
+# Schedule Events (Query Side)
+
+- Topic: `schedule.events`
+- Key: `scheduleId` (UUID)
+- Serialization: JSON (LocalDateTime, KST 기준)
+- Event types: CREATED | UPDATED | DELETED (소스는 `source` 필드로 구분: CUSTOM/DATING/STUDY)
+
+## Common Fields
+- eventId (UUID): 이벤트 식별자
+- eventType (string): CREATED | UPDATED | DELETED
+- scheduleId (UUID): 스케줄 식별자(파티션 키)
+- ownerId (UUID): 소유자 식별자
+- source (string): CUSTOM | DATING | STUDY
+- version (long): Aggregate 버전(@Version) — 순서/아이덴포턴시 보조
+- occurredAt (LocalDateTime): 이벤트 발생 시각(KST 기준)
+
+## Events
+
+### ScheduleCreated
+- 스냅샷 전체 전달
+- Payload
+  - title (string), description (string|null)
+  - startAt (LocalDateTime), endAt (LocalDateTime)
+
+예시
+{
+  "eventId": "b02c0e32-9b6c-4c3e-9a0d-8a5b8b1b1e10",
+  "eventType": "CREATED",
+  "scheduleId": "8f8e5d5e-63d7-4a4e-9d2f-1b93b9a1e0c7",
+  "ownerId": "4c9d3e20-2fda-4ab0-8631-0c2f9b8c2d11",
+  "title": "스터디 모임",
+  "description": "자료 준비",
+  "startAt": "2025-10-01T10:00:00",
+  "endAt": "2025-10-01T12:00:00",
+  "source": "CUSTOM",
+  "version": 1,
+  "occurredAt": "2025-09-24T15:15:30"
+}
+
+### ScheduleUpdated
+- 패치 이후 상태 스냅샷 전체 전달(필드 구성은 ScheduleCreated와 동일)
+
+### ScheduleDeleted
+- 삭제 의도 전달(최소 페이로드)
+- title/description/startAt/endAt 없음
+
+예시
+{
+  "eventId": "a3b1c4de-5f67-4890-90ab-22ccdd3311ff",
+  "eventType": "DELETED",
+  "scheduleId": "8f8e5d5e-63d7-4a4e-9d2f-1b93b9a1e0c7",
+  "ownerId": "4c9d3e20-2fda-4ab0-8631-0c2f9b8c2d11",
+  "source": "CUSTOM",
+  "version": 3,
+  "occurredAt": "2025-09-24T16:00:00"
+}
+
+## Consumer Guidance (Query Side)
+- Upsert
+  - CREATED/UPDATED: `scheduleId` 기준 upsert
+- Delete
+  - DELETED: `scheduleId` 기준 삭제
+- Ordering/Idempotency
+  - 메시지 키: `scheduleId`, `version`으로 재처리 방지 및 순서 보조

--- a/src/main/java/grewmeet/schedulecommandservice/event/publisher/ScheduleEventPublisher.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/publisher/ScheduleEventPublisher.java
@@ -1,0 +1,14 @@
+package grewmeet.schedulecommandservice.event.publisher;
+
+import grewmeet.schedulecommandservice.domain.Schedule;
+import java.util.UUID;
+
+public interface ScheduleEventPublisher {
+
+    void publishCreated(Schedule schedule);
+
+    void publishUpdated(Schedule schedule);
+
+    void publishDeleted(UUID scheduleId, UUID ownerId);
+}
+

--- a/src/main/java/grewmeet/schedulecommandservice/event/publisher/ScheduleEventPublisherImpl.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/publisher/ScheduleEventPublisherImpl.java
@@ -1,0 +1,90 @@
+package grewmeet.schedulecommandservice.event.publisher;
+
+import grewmeet.schedulecommandservice.domain.Schedule;
+import grewmeet.schedulecommandservice.event.schema.ScheduleCreated;
+import grewmeet.schedulecommandservice.event.schema.ScheduleDeleted;
+import grewmeet.schedulecommandservice.event.schema.ScheduleUpdated;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduleEventPublisherImpl implements ScheduleEventPublisher {
+
+    private static final String TOPIC = "schedule.events";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void publishCreated(Schedule schedule) {
+        ScheduleCreated payload = new ScheduleCreated(
+                schedule.getScheduleId(),
+                schedule.getOwnerId(),
+                schedule.getTitle(),
+                schedule.getDescription(),
+                schedule.getStartAt(),
+                schedule.getEndAt(),
+                schedule.getSource(),
+                getVersionOrDefault(schedule.getVersion()),
+                LocalDateTime.now()
+        );
+        send(schedule.getScheduleId(), payload, "CREATED");
+    }
+
+    @Override
+    public void publishUpdated(Schedule schedule) {
+        ScheduleUpdated payload = new ScheduleUpdated(
+                schedule.getScheduleId(),
+                schedule.getOwnerId(),
+                schedule.getTitle(),
+                schedule.getDescription(),
+                schedule.getStartAt(),
+                schedule.getEndAt(),
+                schedule.getSource(),
+                getVersionOrDefault(schedule.getVersion()),
+                LocalDateTime.now()
+        );
+        send(schedule.getScheduleId(), payload, "UPDATED");
+    }
+
+    @Override
+    public void publishDeleted(UUID scheduleId, UUID ownerId) {
+        ScheduleDeleted payload = new ScheduleDeleted(
+                scheduleId,
+                ownerId,
+                grewmeet.schedulecommandservice.domain.ScheduleSource.CUSTOM,
+                0L,
+                LocalDateTime.now()
+        );
+        send(scheduleId, payload, "DELETED");
+    }
+
+    private long getVersionOrDefault(Long version) {
+        if (version != null) {
+            return version;
+        }
+        return 0L;
+    }
+
+    private void send(UUID scheduleId, Object payload, String tag) {
+        String key = scheduleId.toString();
+        kafkaTemplate.send(TOPIC, key, payload).whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("Schedule event published [{}]: topic={}, key={}, partition={}, offset={}",
+                        tag,
+                        TOPIC,
+                        key,
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+                return;
+            }
+            log.error("Schedule event publish failed [{}]: topic={}, key={}", tag, TOPIC, key, ex);
+        });
+    }
+}

--- a/src/main/java/grewmeet/schedulecommandservice/event/schema/ScheduleCreated.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/schema/ScheduleCreated.java
@@ -1,0 +1,18 @@
+package grewmeet.schedulecommandservice.event.schema;
+
+import grewmeet.schedulecommandservice.domain.ScheduleSource;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ScheduleCreated(
+        UUID scheduleId,
+        UUID ownerId,
+        String title,
+        String description,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        ScheduleSource source,
+        long version,
+        LocalDateTime occurredAt
+) {}

--- a/src/main/java/grewmeet/schedulecommandservice/event/schema/ScheduleDeleted.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/schema/ScheduleDeleted.java
@@ -1,0 +1,14 @@
+package grewmeet.schedulecommandservice.event.schema;
+
+import grewmeet.schedulecommandservice.domain.ScheduleSource;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ScheduleDeleted(
+        UUID scheduleId,
+        UUID ownerId,
+        ScheduleSource source,
+        long version,
+        LocalDateTime occurredAt
+) {}

--- a/src/main/java/grewmeet/schedulecommandservice/event/schema/ScheduleUpdated.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/schema/ScheduleUpdated.java
@@ -1,0 +1,18 @@
+package grewmeet.schedulecommandservice.event.schema;
+
+import grewmeet.schedulecommandservice.domain.ScheduleSource;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ScheduleUpdated(
+        UUID scheduleId,
+        UUID ownerId,
+        String title,
+        String description,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        ScheduleSource source,
+        long version,
+        LocalDateTime occurredAt
+) {}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,17 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        # 이벤트 페이로드를 깔끔한 JSON으로 전송(타입 헤더 제거)
+        spring.json.add.type.headers: false
+        # 날짜/시간을 ISO-8601 문자열로 직렬화(타임스탬프 금지)
+        spring.json.write_dates_as_timestamps: false
+    # 소비자는 현재 사용 안 함(향후 Query Side 리스너 추가 시 설정)
+    consumer:
+      group-id: schedule-command-service
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+


### PR DESCRIPTION
 ## Summary
- 커스텀 스케줄 생성/수정/삭제 시 Query Side로 이벤트 발행
- 레코드 페이로드(JSON) 그대로 비동기 전송, 단일 토픽 사용(schedule.events)
- 서비스 계층에서 아웃바운드 퍼블리셔 호출로 연결

## Schedule Command Service — TODO
 - [x] 커스텀 스케쥴 기능 구현
    - [x] 커스텀 스케줄 생성 서비스 구현
    - [x] 커스텀 스케줄 수정(PATCH) 서비스 구현
    - [x] 커스텀 스케줄 삭제 서비스 구현
- [x] Kafka EventHandler(Publisher) 구현 (Command to Query)
- [ ] Kafka EventHandler(Subscriber) 구현 (from Dating Domain, Study Domain)
- [ ] DTO 입력 제약(길이/형식 등) 정교화
- [ ] 운영 프로필(MySQL) DDL 검증 및 마이그레이션(Flyway/Liquibase) 준비

## Changes
- 이벤트 스키마 추가          
    - ScheduleCreated, ScheduleUpdated, ScheduleDeleted (LocalDateTime, source 포함)
- 퍼블리셔 포트/구현
    - ScheduleEventPublisher, ScheduleEventPublisherImpl
    - 토픽: schedule.events, 키: scheduleId
    - 성공/실패 로그 출력(파티션/오프셋 포함)
- 서비스 연동
    - 생성/수정/삭제 후 각각 이벤트 발행
- 설정
    - application-dev.yml: Kafka JsonSerializer 사용, 타입 헤더 비활성화, ISO-8601 문자열 직렬화 