### PR TITLE
feat: 커스텀 스케줄 이벤트 발행 + Study 참가 이벤트 리스너 도입(MVP)

### DIFF
--- a/src/main/java/grewmeet/schedulecommandservice/event/listener/study/StudyMeetingEventListener.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/listener/study/StudyMeetingEventListener.java
@@ -1,0 +1,62 @@
+package grewmeet.schedulecommandservice.event.listener.study;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import grewmeet.schedulecommandservice.event.listener.study.schema.StudyMeetingEventParticipationRegistered;
+import grewmeet.schedulecommandservice.event.listener.study.schema.StudyMeetingParticipationCancelled;
+import grewmeet.schedulecommandservice.event.listener.study.schema.StudyMeetingParticipationCompleted;
+import grewmeet.schedulecommandservice.service.StudyScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyMeetingEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(StudyMeetingEventListener.class);
+
+    private final StudyScheduleService studyScheduleService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "study.meeting.participation.registered", groupId = "schedule-command-service")
+    public void onParticipationRegistered(String payload) {
+        try {
+            StudyMeetingEventParticipationRegistered event =
+                    objectMapper.readValue(payload, StudyMeetingEventParticipationRegistered.class);
+            studyScheduleService.register(
+                    event.userId(),
+                    event.meetingId(),
+                    event.meetingName(),
+                    event.description(),
+                    event.startAt(),
+                    event.endAt()
+            );
+        } catch (Exception e) {
+            log.error("Failed to parse Study Registered payload", e);
+        }
+    }
+
+    @KafkaListener(topics = "study.meeting.participation.cancelled", groupId = "schedule-command-service")
+    public void onParticipationCancelled(String payload) {
+        try {
+            StudyMeetingParticipationCancelled event =
+                    objectMapper.readValue(payload, StudyMeetingParticipationCancelled.class);
+            studyScheduleService.delete(event.userId(), event.meetingId());
+        } catch (Exception e) {
+            log.error("Failed to parse Study Cancelled payload", e);
+        }
+    }
+
+    @KafkaListener(topics = "study.meeting.participation.completed", groupId = "schedule-command-service")
+    public void onParticipationCompleted(String payload) {
+        try {
+            StudyMeetingParticipationCompleted event =
+                    objectMapper.readValue(payload, StudyMeetingParticipationCompleted.class);
+            studyScheduleService.delete(event.userId(), event.meetingId());
+        } catch (Exception e) {
+            log.error("Failed to parse Study Completed payload", e);
+        }
+    }
+}

--- a/src/main/java/grewmeet/schedulecommandservice/event/listener/study/schema/StudyMeetingEventParticipationRegistered.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/listener/study/schema/StudyMeetingEventParticipationRegistered.java
@@ -1,0 +1,17 @@
+package grewmeet.schedulecommandservice.event.listener.study.schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StudyMeetingEventParticipationRegistered(
+        UUID studyGroupId,
+        UUID meetingId,
+        UUID userId,
+        String studyGroupName,
+        String meetingName,
+        String description,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        LocalDateTime joinedAt
+) {}
+

--- a/src/main/java/grewmeet/schedulecommandservice/event/listener/study/schema/StudyMeetingParticipationCancelled.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/listener/study/schema/StudyMeetingParticipationCancelled.java
@@ -1,0 +1,10 @@
+package grewmeet.schedulecommandservice.event.listener.study.schema;
+
+import java.util.UUID;
+
+public record StudyMeetingParticipationCancelled(
+        UUID studyGroupId,
+        UUID meetingId,
+        UUID userId
+) {}
+

--- a/src/main/java/grewmeet/schedulecommandservice/event/listener/study/schema/StudyMeetingParticipationCompleted.java
+++ b/src/main/java/grewmeet/schedulecommandservice/event/listener/study/schema/StudyMeetingParticipationCompleted.java
@@ -1,0 +1,14 @@
+package grewmeet.schedulecommandservice.event.listener.study.schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StudyMeetingParticipationCompleted(
+        UUID studyGroupId,
+        UUID meetingId,
+        UUID userId,
+        String studyGroupName,
+        String meetingName,
+        LocalDateTime completedAt
+) {}
+

--- a/src/main/java/grewmeet/schedulecommandservice/service/StudyScheduleService.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/StudyScheduleService.java
@@ -1,0 +1,24 @@
+package grewmeet.schedulecommandservice.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface StudyScheduleService {
+
+    void register(UUID userId,
+                  UUID meetingId,
+                  String meetingName,
+                  String description,
+                  LocalDateTime startAt,
+                  LocalDateTime endAt);
+
+    void update(UUID userId,
+                UUID meetingId,
+                String newMeetingName,
+                String newDescription,
+                LocalDateTime newStartAt,
+                LocalDateTime newEndAt);
+
+    void delete(UUID userId,
+                UUID meetingId);
+}

--- a/src/main/java/grewmeet/schedulecommandservice/service/StudyScheduleServiceImpl.java
+++ b/src/main/java/grewmeet/schedulecommandservice/service/StudyScheduleServiceImpl.java
@@ -1,0 +1,95 @@
+package grewmeet.schedulecommandservice.service;
+
+import grewmeet.schedulecommandservice.domain.Schedule;
+import grewmeet.schedulecommandservice.event.publisher.ScheduleEventPublisher;
+import grewmeet.schedulecommandservice.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StudyScheduleServiceImpl implements StudyScheduleService {
+
+    private static final Logger log = LoggerFactory.getLogger(StudyScheduleServiceImpl.class);
+
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleEventPublisher scheduleEventPublisher;
+
+    @Override
+    public void register(UUID userId,
+                         UUID meetingId,
+                         String meetingName,
+                         String description,
+                         LocalDateTime startAt,
+                         LocalDateTime endAt) {
+        UUID scheduleId = deterministicScheduleId(meetingId, userId);
+        UUID ownerId = userId;
+
+        Optional<Schedule> existing = scheduleRepository.findByScheduleIdAndOwnerId(scheduleId, ownerId);
+        if (existing.isPresent()) {
+            Schedule schedule = existing.get();
+            schedule.applyPatch(meetingName, description, startAt, endAt);
+            Schedule saved = scheduleRepository.save(schedule);
+            scheduleEventPublisher.publishUpdated(saved);
+            log.info("Study register -> Updated schedule: scheduleId={}, ownerId={}", scheduleId, ownerId);
+            return;
+        }
+
+        Schedule created = Schedule.createCustom(ownerId, scheduleId, meetingName, description, startAt, endAt);
+        Schedule saved = scheduleRepository.save(created);
+        scheduleEventPublisher.publishCreated(saved);
+        log.info("Study register -> Created schedule: scheduleId={}, ownerId={}", scheduleId, ownerId);
+    }
+
+    @Override
+    public void update(UUID userId,
+                       UUID meetingId,
+                       String newMeetingName,
+                       String newDescription,
+                       LocalDateTime newStartAt,
+                       LocalDateTime newEndAt) {
+        UUID scheduleId = deterministicScheduleId(meetingId, userId);
+        UUID ownerId = userId;
+
+        Optional<Schedule> existing = scheduleRepository.findByScheduleIdAndOwnerId(scheduleId, ownerId);
+        if (existing.isEmpty()) {
+            log.info("Study update -> Schedule not found: scheduleId={}, ownerId={}", scheduleId, ownerId);
+            return;
+        }
+
+        Schedule schedule = existing.get();
+        schedule.applyPatch(newMeetingName, newDescription, newStartAt, newEndAt);
+        Schedule saved = scheduleRepository.save(schedule);
+        scheduleEventPublisher.publishUpdated(saved);
+        log.info("Study update -> Updated schedule: scheduleId={}, ownerId={}", scheduleId, ownerId);
+    }
+
+    @Override
+    public void delete(UUID userId, UUID meetingId) {
+        UUID scheduleId = deterministicScheduleId(meetingId, userId);
+        UUID ownerId = userId;
+
+        Optional<Schedule> existing = scheduleRepository.findByScheduleIdAndOwnerId(scheduleId, ownerId);
+        if (existing.isEmpty()) {
+            log.info("Study delete -> Schedule not found: scheduleId={}, ownerId={}", scheduleId, ownerId);
+            return;
+        }
+
+        Schedule schedule = existing.get();
+        scheduleRepository.delete(schedule);
+        scheduleEventPublisher.publishDeleted(scheduleId, ownerId);
+        log.info("Study delete -> Deleted schedule: scheduleId={}, ownerId={}", scheduleId, ownerId);
+    }
+
+    private UUID deterministicScheduleId(UUID meetingId, UUID userId) {
+        String key = "study:" + meetingId + ":" + userId;
+        return UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,8 +10,14 @@ spring:
         # 날짜/시간을 ISO-8601 문자열로 직렬화(타임스탬프 금지)
         spring.json.write_dates_as_timestamps: false
     # 소비자는 현재 사용 안 함(향후 Query Side 리스너 추가 시 설정)
-    consumer:
+  consumer:
       group-id: schedule-command-service
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
+app:
+  study:
+    topics:
+      participation-registered: study.meeting.participation.registered
+      participation-cancelled: study.meeting.participation.cancelled
+      participation-completed: study.meeting.participation.completed


### PR DESCRIPTION
## Summary
 - 커스텀 스케줄 생성/수정/삭제 시 Query Side로 이벤트 발행 유지
  - Study 도메인 참가 이벤트 수신 리스너 추가(Registered/Cancelled/Completed)
  - 리스너는 문자열 페이로드 수신 → ObjectMapper로 파싱 → 애플리케이션 서비스로 위임
  - 단일 토픽 설계 유지(schedule.events는 아웃바운드), 인바운드는 Study 전용 토픽
  구독

## Schedule Command Service — TODO
 - [x] 커스텀 스케쥴 기능 구현
    - [x] 커스텀 스케줄 생성 서비스 구현
    - [x] 커스텀 스케줄 수정(PATCH) 서비스 구현
    - [x] 커스텀 스케줄 삭제 서비스 구현
- [x] Kafka EventHandler(Publisher) 구현 (Command to Query)
- [ ] Kafka EventHandler(Subscriber) 구현 (from Dating Domain, Study Domain)
    - [x] from Study Domain
    - [ ] from Dating Domain 
- [ ] DTO 입력 제약(길이/형식 등) 정교화
- [ ] 운영 프로필(MySQL) DDL 검증 및 마이그레이션(Flyway/Liquibase) 준비

## Changes

  - 인바운드 스키마(Study)
      - StudyMeetingEventParticipationRegistered,
  StudyMeetingParticipationCancelled, StudyMeetingParticipationCompleted
      - 위치: grewmeet.schedulecommandservice.event.listener.study.schema
  - 이벤트 리스너/서비스
      - StudyMeetingEventListener: 간단한 @KafkaListener(topics/groupId만)
      - StudyScheduleService/StudyScheduleServiceImpl: 등록(register)/삭제(delete)
  유스케이스 제공
      - 결정적 scheduleId = UUID.nameUUIDFromBytes("study:"+meetingId+":"+userId)로
  멱등 처리
  - 설정
      - dev: 토픽 기본값 유지(리스너 애노테이션에 리터럴로 명시)
      - 컨슈머 팩토리 클래스 제거(부트 기본 컨슈머 사용)
  - 아웃바운드(기존 유지)
      - ScheduleEventPublisher/ScheduleEventPublisherImpl
      - 토픽: schedule.events, 키: scheduleId
      - 성공/실패 로그(파티션/오프셋 포함)
## Known Limitations

  - Study 이벤트로 생성된 일정의 source가 현재 CUSTOM으로 저장/발행됨(도메인 팩토리
  미정). 후속으로 createStudy(...) 추가 및 삭제 퍼블리시 시그니처 개선 예정.
  - Dating 도메인 구독 미구현(스키마 확정 대기).

## How to Test (로컬)
  - 빌드: ./gradlew clean build
  - 실행: ./gradlew bootRun
  - 토픽 송신 예시
      - Registered → study.meeting.participation.registered
      - Cancelled → study.meeting.participation.cancelled
      - Completed → study.meeting.participation.completed
      - 페이로드는 각 레코드 스키마에 맞춘 JSON 사용

 ## Follow-ups

  - Study 생성 시 source=STUDY 저장/발행하도록 도메인 팩토리 추가
  - 삭제 퍼블리셔를 값 기반 시그니처로 정리(EDA 결합도 완화)
  - Dating 도메인 리스너 추가
  - 입력 DTO 검증(문자열 길이/형식, 날짜 일관성) 강화